### PR TITLE
MB-13095 fdb_get_byoffset fails if only offset specified

### DIFF
--- a/src/forestdb.cc
+++ b/src/forestdb.cc
@@ -1538,6 +1538,7 @@ fdb_status fdb_doc_create(fdb_doc **doc, const void *key, size_t keylen,
         (*doc)->bodylen = 0;
     }
 
+    (*doc)->seqnum = SEQNUM_NOT_USED;
     (*doc)->size_ondisk = 0;
     (*doc)->deleted = false;
 


### PR DESCRIPTION
Example:

```rust
let mut doc: *mut ffi::fdb_doc = ptr::null_mut();
ffi::fdb_doc_create(&mut doc,
                    ptr::null_mut(), 0,
                    ptr::null_mut(), 0,
                    ptr::null_mut(), 0);
(*doc).offset = doc1.offset(); // actual offset
// if this line is missing - result is key not found error
(*doc).seqnum = 0xffffffffffffffff;
// (*doc).seqnum = doc1.seq_num(); // this works too

let res = ffi::fdb_get_byoffset(store.get_raw(), doc);
assert_eq!(res, 0);
```

Happened because `fdb_doc_create` sets `seqnum` to 0 and later on
`equal_doc` returns false as considers 0 to be a correct value to check
against found document.